### PR TITLE
Fix nil error and allow accented characters

### DIFF
--- a/lib/avatarly.rb
+++ b/lib/avatarly.rb
@@ -66,8 +66,7 @@ class Avatarly
 
     def initials_for_separator(text, separator)
       if text.include?(separator)
-        text = text.split(separator)
-        text[0][0] + text[1][0]
+        text.split(separator).compact.map { |part| part[0] }.join
       else
         text[0] || ''
       end

--- a/lib/avatarly.rb
+++ b/lib/avatarly.rb
@@ -15,7 +15,7 @@ class Avatarly
 
   class << self
     def generate_avatar(text, opts={})
-      text = initials(text.to_s.strip.gsub(/[^\w@ ]/,''))
+      text = initials(text.to_s.strip.gsub(/[^[[:word:]]@ ]/,''))
       text = text.upcase if opts[:upcase]
 
       opts = parse_options(opts)

--- a/spec/avatarly_spec.rb
+++ b/spec/avatarly_spec.rb
@@ -57,6 +57,18 @@ describe Avatarly do
         assert_image_equality(result, :H_black_white_32)
       end
 
+      it 'does not break if input has a space and non-word character' do
+        result = described_class.generate_avatar("H !",
+                                                 background_color: "#000000")
+        assert_image_equality(result, :H_black_white_32)
+      end
+
+      it 'does not break if input has a dot and non-word character' do
+        result = described_class.generate_avatar("H.!",
+                                                 background_color: "#000000")
+        assert_image_equality(result, :H_black_white_32)
+      end
+
       it 'does not break if input has leading or trailing non-word character' do
         result = described_class.generate_avatar("%HelloWorld!",
                                                  background_color: "#000000")


### PR DESCRIPTION
- Fix nil error
  Prevents 500's when characters such as `"ひ ら"` are entered
- Prevent accented characters from being stripped out
  Allows the generation of avatars such as `"ñ ñ"` by using a different regex