### PR TITLE
Remove old packages to support Ruby 3.3

### DIFF
--- a/avatarly.gemspec
+++ b/avatarly.gemspec
@@ -1,6 +1,5 @@
 Gem::Specification.new do |s|
   s.add_runtime_dependency('rmagick')
-  s.add_runtime_dependency('rfc822')
   s.add_runtime_dependency('unicode_utils')
 
   s.name        = "avatarly"

--- a/avatarly.gemspec
+++ b/avatarly.gemspec
@@ -1,9 +1,8 @@
 Gem::Specification.new do |s|
   s.add_runtime_dependency('rmagick')
-  s.add_runtime_dependency('unicode_utils')
 
   s.name        = "avatarly"
-  s.version     = "1.6.1"
+  s.version     = "1.6.1.1"
   s.summary     = "Simple gem for creating gmail-like user avatars with initials."
   s.description = "Avatarly is a simple gem for Ruby that creates gmail-like avatars with initials, inspired by avatar-generator by johnnyhalife. See homepage for more information."
   s.authors     = ["Lukasz Odziewa", "Artur Trzop"]

--- a/lib/avatarly.rb
+++ b/lib/avatarly.rb
@@ -1,5 +1,4 @@
 require 'rvg/rvg'
-require 'rfc822'
 require 'pathname'
 
 class Avatarly
@@ -57,8 +56,6 @@ class Avatarly
     def initials(text, opts)
       if opts[:separator]
         initials_for_separator(text, opts[:separator])
-      elsif text.is_email?
-        initials_for_separator(text.split("@").first, ".")
       elsif text.include?(" ")
         initials_for_separator(text, " ")
       else

--- a/spec/avatarly_spec.rb
+++ b/spec/avatarly_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Avatarly do
   describe '.generate_avatar' do
-    it 'generates avatar for given email address' do
+    it 'for the provided name' do
       result = described_class.generate_avatar("hello",
                                                background_color: "#000000")
       assert_image_equality(result, :HW_black_white_32, 34)

--- a/spec/avatarly_spec.rb
+++ b/spec/avatarly_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Avatarly do
   describe '.generate_avatar' do
     it 'generates avatar for given email address' do
-      result = described_class.generate_avatar("hello.world@example.com",
+      result = described_class.generate_avatar("hello",
                                                background_color: "#000000")
       assert_image_equality(result, :HW_black_white_32, 34)
     end
@@ -21,13 +21,13 @@ describe Avatarly do
 
     context 'accepts parameters for format' do
       it '.png'  do
-        result = described_class.generate_avatar("hello.world@example.com",
+        result = described_class.generate_avatar("hello world",
                                                  format: "png")
         assert_image_format(result, :png)
       end
 
       it '.jpg' do
-        result = described_class.generate_avatar("hello.world@example.com",
+        result = described_class.generate_avatar("hello world",
                                                  format: "jpeg")
         assert_image_format(result, :jpeg)
       end


### PR DESCRIPTION
In order to upgrade to Ruby 3.3 we need to resolve the deprecation warnings caused by the `rfc822` package. This package is from 2014 and is not receiving updates. So I have chosen to remove the email functionality and the package as Storypark does not pass emails into Avatarly.

I've also removed the `unicode_utils`, it is a library from 2012 and doesn't seem to be required in modern ruby.

```console
$ bundle exec ruby --version && bundle exec rspec
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
/Users/opalsymes/.gem/ruby/3.3.0/gems/fastimage-2.3.0/lib/fastimage.rb:62: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of fastimage-2.3.0 to add base64 into its gemspec.

Avatarly
  .generate_avatar
    generates avatar for given email address
    accepts parameters for size, background, vertical_offset and font colors
    accepts parameters for format
      .png
      .jpg
    non-email input
      uses first letters of first two space separated words
      falls back to dot-separated words when no spaces in input
      falls back to single-letter avatar when no dots and spaces found
      can generate using custom separators
      does not break if input has leading or trailing space
      does not break if input has a space and non-word character
      does not break if input has a dot and non-word character
      does not break if input has leading or trailing non-word character
      does not break if no text found
      strips leading/trailing whitespace without striping other whitespaces

Finished in 0.10105 seconds (files took 0.14536 seconds to load)
14 examples, 0 failures
```